### PR TITLE
Disable password signups by default

### DIFF
--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -78,6 +78,11 @@ export const settings: settingsType[] = [
     shortName: "DeleteInactiveUser",
     variant: "number",
   },
+  {
+    name: "Enable Signups with passwords",
+    shortName: "EnablePasswordSignup",
+    variant: "boolean",
+  },
 ];
 interface LeaguePluginsProps {
   plugins: plugins[];
@@ -633,7 +638,14 @@ function Config({
   variant,
   options,
 }: configProps) {
-  const [value, setValue] = useState(default_value);
+  console.log(default_value);
+  const [value, setValue] = useState(
+    variant === "boolean"
+      ? default_value === "1"
+        ? true
+        : false
+      : default_value,
+  );
   const notify = useContext(NotifyContext);
   const save = async () => {
     notify("Saving");
@@ -680,6 +692,24 @@ function Config({
               </MenuItem>
             ))}
           </Select>
+          <Button variant="outlined" color="success" onClick={save}>
+            Save
+          </Button>
+          <br />
+        </>
+      );
+    case "boolean":
+      return (
+        <>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={Boolean(value)}
+                onChange={(e) => setValue(e.target.checked)}
+              />
+            }
+            label={name}
+          />
           <Button variant="outlined" color="success" onClick={save}>
             Save
           </Button>

--- a/pages/api/admin/config.ts
+++ b/pages/api/admin/config.ts
@@ -43,6 +43,8 @@ export default async function handler(
               if (!(value >= 0)) {
                 fail = true;
               }
+            } else if (setting[0].variant === "boolean") {
+              value = value ? 1 : 0;
             }
           } else {
             res.status(400).end("Config value not found");
@@ -52,6 +54,19 @@ export default async function handler(
       if (fail) {
         if (!res.writableEnded) res.status(400).end("Config value was invalid");
         return;
+      }
+      // If the signup with password value was changed regenerate the signin page
+      if (name === "EnablePasswordSignup") {
+        fetch(process.env.NEXTAUTH_URL_INTERNAL + "/api/revalidate", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            secret: process.env.NEXTAUTH_SECRET,
+            path: "/signin",
+          }),
+        });
       }
       const connection = await connect();
       await connection.query(

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -11,11 +11,16 @@ import { Providers, getProviders } from "../types/providers";
 import Link from "../components/Link";
 import { TranslateContext } from "../Modules/context";
 import getLocales from "../locales/getLocales";
+import connect from "#/Modules/database";
 interface Props {
   enabledProviders: Providers[];
+  enablePasswordSignup: boolean;
 }
 
-export default function SignIn({ enabledProviders }: Props) {
+export default function SignIn({
+  enabledProviders,
+  enablePasswordSignup,
+}: Props) {
   const t = useContext(TranslateContext);
   const router = useRouter();
   const callbackUrl = router.query.callbackUrl as string;
@@ -139,12 +144,16 @@ export default function SignIn({ enabledProviders }: Props) {
         >
           {t("Sign In")}
         </Button>
-        <Button
-          variant="contained"
-          onClick={() => signIn("Sign-Up", { callbackUrl, username, password })}
-        >
-          {t("Sign Up")}
-        </Button>
+        {enablePasswordSignup && (
+          <Button
+            variant="contained"
+            onClick={() =>
+              signIn("Sign-Up", { callbackUrl, username, password })
+            }
+          >
+            {t("Sign Up")}
+          </Button>
+        )}
         <p>
           {" "}
           <Link href="privacy">
@@ -159,8 +168,14 @@ export default function SignIn({ enabledProviders }: Props) {
 }
 // Gets the list of providers
 export const getStaticProps: GetStaticProps = async (ctx) => {
+  const connection = await connect();
   const props: Props = {
     enabledProviders: getProviders(),
+    enablePasswordSignup: await connection
+      .query(
+        "SELECT * FROM data WHERE value1='configEnablePasswordSignup' AND value2='1'",
+      )
+      .then((res) => res.length > 0),
   };
   return { props: { ...props, t: await getLocales(ctx.locale) } };
 };

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -171,11 +171,13 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
   const connection = await connect();
   const props: Props = {
     enabledProviders: getProviders(),
-    enablePasswordSignup: await connection
-      .query(
-        "SELECT * FROM data WHERE value1='configEnablePasswordSignup' AND value2='1'",
-      )
-      .then((res) => res.length > 0),
+    enablePasswordSignup:
+      getProviders().length === 0 ||
+      (await connection
+        .query(
+          "SELECT * FROM data WHERE value1='configEnablePasswordSignup' AND value2='1'",
+        )
+        .then((res) => res.length > 0)),
   };
   return { props: { ...props, t: await getLocales(ctx.locale) } };
 };

--- a/scripts/startup.ts
+++ b/scripts/startup.ts
@@ -20,7 +20,8 @@ const currentVersion = "1.15.0";
 async function createConfig() {
   const connection = await connect();
   await connection.query(
-    "INSERT IGNORE INTO data (value1, value2) VALUES ('configMinTimeGame', '120'), ('configMaxTimeGame', '1200'), ('configMinTimeTransfer', '3600'), ('configMaxTimeTransfer', '86400'), ('configDownloadPicture', 'needed'), ('configDeleteInactiveUser', '0'), ('configArchiveInactiveLeague', '180')",
+    "INSERT IGNORE INTO data (value1, value2) VALUES ('configMinTimeGame', '120'), ('configMaxTimeGame', '1200'), ('configMinTimeTransfer', '3600'), ('configMaxTimeTransfer', '86400'), ('configDownloadPicture', 'needed'), ('configDeleteInactiveUser', '0'), ('configArchiveInactiveLeague', '180'), ('configEnablePasswordSignup', ?)",
+    [process.env.APP_ENV !== "production"],
   );
   if (process.env.APP_ENV === "test") {
     await connection.query(


### PR DESCRIPTION
This change has been released to increase the security due to accounts with passwords being inherently more insecure than oauth accounts. This change does not disable the login of users that already have an account that logs in with a password, or prevents users from enabling password login after account creation. You may also re enable password signups in the admin panel. Also note that if you have no oauth providers enabled password signups will also be enabled.